### PR TITLE
Fix README example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Aurelia
     CardiganConfiguration,
   )
   .app(App)
-  .start(
+  .start();
 ```
 
 ## Components


### PR DESCRIPTION
## Summary
- fix `.start()` call in README
- ensure code blocks close properly

## Testing
- `npm test` *(fails: jest not found)*