### PR TITLE
Add badge component

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Cardigan features a small, but growing number of components.
 - `<au-modal>` a lightweight modal implementation
 - `<au-select>` wraps the native select element
 - `<au-code>` displays code snippets using `<pre>` or `<code>`
+- `<au-badge>` displays a small label that can be color coded
 
 ## Styling Components
 

--- a/src/components/au-badge.css
+++ b/src/components/au-badge.css
@@ -1,0 +1,66 @@
+:host {
+    --badge-background: var(--color-primary);
+    --badge-color: var(--color-white);
+    --badge-font-size: 0.75rem;
+    --badge-padding: 0.25rem 0.5rem;
+    --badge-border-radius: 0.25rem;
+}
+
+.badge {
+    background: var(--badge-background);
+    border-radius: var(--badge-border-radius);
+    color: var(--badge-color);
+    display: inline-block;
+    font-size: var(--badge-font-size);
+    padding: var(--badge-padding);
+}
+
+.primary {
+    background: var(--color-primary);
+    color: var(--color-white);
+}
+
+.secondary {
+    background: var(--color-secondary);
+    color: var(--color-white);
+}
+
+.success {
+    background: var(--color-success);
+    color: var(--color-white);
+}
+
+.error {
+    background: var(--color-error);
+    color: var(--color-white);
+}
+
+.info {
+    background: var(--color-info);
+    color: var(--color-white);
+}
+
+.light {
+    background: var(--color-light);
+    color: var(--color-dark);
+}
+
+.dark {
+    background: var(--color-dark);
+    color: var(--color-white);
+}
+
+.small {
+    font-size: 0.625rem;
+    padding: 0.125rem 0.25rem;
+}
+
+.medium {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+}
+
+.large {
+    font-size: 0.875rem;
+    padding: 0.375rem 0.75rem;
+}

--- a/src/components/au-badge.html
+++ b/src/components/au-badge.html
@@ -1,0 +1,1 @@
+<span class="badge ${color} ${size}" part="badge ${color} ${size}"><slot></slot></span>

--- a/src/components/au-badge.ts
+++ b/src/components/au-badge.ts
@@ -1,0 +1,17 @@
+import { bindable, customElement, ICustomElementViewModel, shadowCSS } from '@aurelia/runtime-html';
+import SharedStyles from '../variables.css';
+import styles from './au-badge.css';
+import template from './au-badge.html';
+
+@customElement({
+  name: 'au-badge',
+  template,
+  dependencies: [
+    shadowCSS(SharedStyles, styles)
+  ],
+  shadowOptions: { mode: 'open' }
+})
+export class AuBadgeCustomElement implements ICustomElementViewModel {
+  @bindable public color: string = 'primary';
+  @bindable public size: 'small' | 'medium' | 'large' = 'medium';
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ import { AuImageCustomElement } from "./au-image";
 import { AuButtonCustomElement } from "./au-button";
 import { AuHeadingCustomElement } from "./au-heading";
 import { AuCodeCustomElement } from "./au-code";
+import { AuBadgeCustomElement } from "./au-badge";
 
 export const DefaultComponents: IRegistry[] = [
   AuButtonCustomElement as unknown as IRegistry,
@@ -14,4 +15,5 @@ export const DefaultComponents: IRegistry[] = [
   AuSelectCustomElement as unknown as IRegistry,
   AuHeadingCustomElement as unknown as IRegistry,
   AuCodeCustomElement as unknown as IRegistry,
+  AuBadgeCustomElement as unknown as IRegistry,
 ];

--- a/test/au-badge.spec.ts
+++ b/test/au-badge.spec.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '@aurelia/testing';
+import { AuBadgeCustomElement } from './../src/components/au-badge';
+
+describe('Badge', () => {
+  test('should render badge', async () => {
+    const { appHost, startPromise, tearDown } = await createFixture('<au-badge>Hi</au-badge>', class App {}, [AuBadgeCustomElement]);
+
+    await startPromise;
+
+    const badge = appHost.querySelector('au-badge')?.shadowRoot?.querySelector('span');
+
+    expect(badge).toBeDefined();
+
+    await tearDown();
+  });
+
+  test('should render badge with color class', async () => {
+    const { appHost, startPromise, tearDown } = await createFixture('<au-badge color="success">Hi</au-badge>', class App {}, [AuBadgeCustomElement]);
+
+    await startPromise;
+
+    const badge = appHost.querySelector('au-badge')?.shadowRoot?.querySelector('span');
+
+    expect(badge?.classList.contains('success')).toBeTruthy();
+
+    await tearDown();
+  });
+});


### PR DESCRIPTION
## Summary
- add `<au-badge>` component implementation and styles
- export badge component
- document badge component in README
- add basic badge component tests

## Testing
- `npm test` *(fails: jest not found)*