### PR TITLE
Add avatar and tooltip components

### DIFF
--- a/src/components/au-avatar.css
+++ b/src/components/au-avatar.css
@@ -1,0 +1,35 @@
+:host {
+  display: inline-block;
+}
+
+.avatar {
+  background: var(--avatar-background, var(--color-lightGrey));
+  color: var(--avatar-color, var(--color-dark));
+  border-radius: 50%;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.small {
+  width: var(--avatar-size-small, 2rem);
+  height: var(--avatar-size-small, 2rem);
+}
+
+.medium {
+  width: var(--avatar-size-medium, 3rem);
+  height: var(--avatar-size-medium, 3rem);
+}
+
+.large {
+  width: var(--avatar-size-large, 4rem);
+  height: var(--avatar-size-large, 4rem);
+}

--- a/src/components/au-avatar.html
+++ b/src/components/au-avatar.html
@@ -1,0 +1,4 @@
+<div class="avatar ${size}" part="avatar ${size}">
+  <img if.bind="src" src.bind="src" alt.bind="alt">
+  <span if.bind="!src">${initials}</span>
+</div>

--- a/src/components/au-avatar.ts
+++ b/src/components/au-avatar.ts
@@ -1,0 +1,17 @@
+import { bindable, customElement, ICustomElementViewModel, shadowCSS } from '@aurelia/runtime-html';
+import SharedStyles from '../variables.css';
+import styles from './au-avatar.css';
+import template from './au-avatar.html';
+
+@customElement({
+  name: 'au-avatar',
+  template,
+  dependencies: [shadowCSS(SharedStyles, styles)],
+  shadowOptions: { mode: 'open' }
+})
+export class AuAvatarCustomElement implements ICustomElementViewModel {
+  @bindable public src: string = '';
+  @bindable public alt: string = '';
+  @bindable public initials: string = '';
+  @bindable public size: 'small' | 'medium' | 'large' = 'medium';
+}

--- a/src/components/au-tooltip.css
+++ b/src/components/au-tooltip.css
@@ -1,0 +1,52 @@
+:host {
+  display: inline-block;
+}
+
+.wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  visibility: hidden;
+  background: var(--tooltip-background, var(--color-dark));
+  color: var(--tooltip-color, var(--color-white));
+  text-align: center;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  position: absolute;
+  z-index: 1;
+  white-space: nowrap;
+}
+
+.wrapper:hover .tooltip {
+  visibility: visible;
+}
+
+.top {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 0.25rem;
+}
+
+.bottom {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0.25rem;
+}
+
+.left {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-right: 0.25rem;
+}
+
+.right {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 0.25rem;
+}

--- a/src/components/au-tooltip.html
+++ b/src/components/au-tooltip.html
@@ -1,0 +1,4 @@
+<span class="wrapper">
+  <slot></slot>
+  <span class="tooltip ${position}" part="tooltip">${message}</span>
+</span>

--- a/src/components/au-tooltip.ts
+++ b/src/components/au-tooltip.ts
@@ -1,0 +1,15 @@
+import { bindable, customElement, ICustomElementViewModel, shadowCSS } from '@aurelia/runtime-html';
+import SharedStyles from '../variables.css';
+import styles from './au-tooltip.css';
+import template from './au-tooltip.html';
+
+@customElement({
+  name: 'au-tooltip',
+  template,
+  dependencies: [shadowCSS(SharedStyles, styles)],
+  shadowOptions: { mode: 'open' }
+})
+export class AuTooltipCustomElement implements ICustomElementViewModel {
+  @bindable public message: string = '';
+  @bindable public position: 'top' | 'bottom' | 'left' | 'right' = 'top';
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,8 @@ import { AuCodeCustomElement } from "./au-code";
 import { AuBadgeCustomElement } from "./au-badge";
 import { AuAlertCustomElement } from "./au-alert";
 import { AuProgressCustomElement } from "./au-progress";
+import { AuAvatarCustomElement } from "./au-avatar";
+import { AuTooltipCustomElement } from "./au-tooltip";
 
 export const DefaultComponents: IRegistry[] = [
   AuButtonCustomElement as unknown as IRegistry,
@@ -20,4 +22,6 @@ export const DefaultComponents: IRegistry[] = [
   AuBadgeCustomElement as unknown as IRegistry,
   AuAlertCustomElement as unknown as IRegistry,
   AuProgressCustomElement as unknown as IRegistry,
+  AuAvatarCustomElement as unknown as IRegistry,
+  AuTooltipCustomElement as unknown as IRegistry,
 ];

--- a/test/au-avatar.spec.ts
+++ b/test/au-avatar.spec.ts
@@ -1,0 +1,40 @@
+import { createFixture } from '@aurelia/testing';
+import { AuAvatarCustomElement } from './../src/components/au-avatar';
+
+describe('Avatar', () => {
+  test('should render image when src provided', async () => {
+    const { appHost, startPromise, tearDown } = await createFixture('<au-avatar src="test.png"></au-avatar>', class App {}, [AuAvatarCustomElement]);
+
+    await startPromise;
+
+    const img = appHost.querySelector('au-avatar')?.shadowRoot?.querySelector('img');
+
+    expect(img).toBeDefined();
+
+    await tearDown();
+  });
+
+  test('should display initials when no image', async () => {
+    const { appHost, startPromise, tearDown } = await createFixture('<au-avatar initials="AB"></au-avatar>', class App {}, [AuAvatarCustomElement]);
+
+    await startPromise;
+
+    const span = appHost.querySelector('au-avatar')?.shadowRoot?.querySelector('span');
+
+    expect(span?.textContent).toBe('AB');
+
+    await tearDown();
+  });
+
+  test('should apply size class', async () => {
+    const { appHost, startPromise, tearDown } = await createFixture('<au-avatar size="large"></au-avatar>', class App {}, [AuAvatarCustomElement]);
+
+    await startPromise;
+
+    const wrapper = appHost.querySelector('au-avatar')?.shadowRoot?.querySelector('.avatar');
+
+    expect(wrapper?.classList.contains('large')).toBeTruthy();
+
+    await tearDown();
+  });
+});

--- a/test/au-tooltip.spec.ts
+++ b/test/au-tooltip.spec.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '@aurelia/testing';
+import { AuTooltipCustomElement } from './../src/components/au-tooltip';
+
+describe('Tooltip', () => {
+  test('should render tooltip text', async () => {
+    const { appHost, startPromise, tearDown } = await createFixture('<au-tooltip message="Hello">Hover</au-tooltip>', class App {}, [AuTooltipCustomElement]);
+
+    await startPromise;
+
+    const tooltip = appHost.querySelector('au-tooltip')?.shadowRoot?.querySelector('.tooltip');
+
+    expect(tooltip?.textContent).toBe('Hello');
+
+    await tearDown();
+  });
+
+  test('should apply position class', async () => {
+    const { appHost, startPromise, tearDown } = await createFixture('<au-tooltip message="Hi" position="bottom">Hover</au-tooltip>', class App {}, [AuTooltipCustomElement]);
+
+    await startPromise;
+
+    const tooltip = appHost.querySelector('au-tooltip')?.shadowRoot?.querySelector('.tooltip');
+
+    expect(tooltip?.classList.contains('bottom')).toBeTruthy();
+
+    await tearDown();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `au-avatar` for user avatars
- introduce `au-tooltip` for simple tooltips
- export the new components
- add unit tests for the new components