### PR TITLE
Add menu components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
     "name": "au-cardigan",
-    "version": "0.0.21",
+    "version": "0.0.27",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "au-cardigan",
-            "version": "0.0.21",
+            "version": "0.0.27",
             "license": "MIT",
             "dependencies": {
-                "@aurelia/kernel": "^2.0.0-beta.7",
-                "@aurelia/runtime": "^2.0.0-beta.7",
-                "@aurelia/runtime-html": "^2.0.0-beta.7"
+                "@aurelia/kernel": "^2.0.0-beta.24",
+                "@aurelia/runtime": "^2.0.0-beta.24",
+                "@aurelia/runtime-html": "^2.0.0-beta.24"
             },
             "devDependencies": {
-                "@aurelia/platform-browser": "^2.0.0-beta.7",
-                "@aurelia/testing": "^2.0.0-beta.7",
-                "@aurelia/ts-jest": "^2.0.0-beta.7",
+                "@aurelia/platform-browser": "^2.0.0-beta.24",
+                "@aurelia/testing": "^2.0.0-beta.24",
+                "@aurelia/ts-jest": "^2.0.0-beta.24",
                 "@rollup/plugin-html": "^0.2.4",
                 "@types/jest": "^28.1.6",
                 "autoprefixer": "^10.4.7",
@@ -51,55 +51,55 @@
             }
         },
         "node_modules/@aurelia/kernel": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/kernel/-/kernel-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/kernel/-/kernel-2.0.0-beta.24.tgz",
             "integrity": "sha512-T2eXGdyfxh9T7xNljUJVbVE2EWsGKtyZYYHmYeE0GoctI6Ia7arN9g191DrXZZslz79nC/1ZFjxcsATx2GipHQ==",
             "dependencies": {
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7"
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24"
             },
             "engines": {
                 "node": ">=14.17.0"
             }
         },
         "node_modules/@aurelia/metadata": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/metadata/-/metadata-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/metadata/-/metadata-2.0.0-beta.24.tgz",
             "integrity": "sha512-/e1PrqErA9eDvw7Wg6LC6z2+F7Kiojfyraq1Sv0OxafiwLq1Oao/TRVL4C0jUZOsRqQ+XXS0iRm+zAQ247Trxg==",
             "engines": {
                 "node": ">=14.17.0"
             }
         },
         "node_modules/@aurelia/platform": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/platform/-/platform-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/platform/-/platform-2.0.0-beta.24.tgz",
             "integrity": "sha512-yimI627UmzbTL8gwQ8G3sDERjGCAXq7ictekvRc0Nena9fZltu/DS4Rln10cGTMTFKAg2SGQ5zsiiVEVXTm0tg==",
             "engines": {
                 "node": ">=14.17.0"
             }
         },
         "node_modules/@aurelia/platform-browser": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/platform-browser/-/platform-browser-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/platform-browser/-/platform-browser-2.0.0-beta.24.tgz",
             "integrity": "sha512-wDzTiu9AzIjkDYitQvnNHjwzH3cmurisp3YwTvdUt5JRwO4qGwWWEea5S2iwSyi9u+xSz/NkWLExb8clVaNMKA==",
             "dependencies": {
-                "@aurelia/platform": "2.0.0-beta.7"
+                "@aurelia/platform": "2.0.0-beta.24"
             },
             "engines": {
                 "node": ">=14.17.0"
             }
         },
         "node_modules/@aurelia/plugin-conventions": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/plugin-conventions/-/plugin-conventions-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/plugin-conventions/-/plugin-conventions-2.0.0-beta.24.tgz",
             "integrity": "sha512-4VLpKQPmuRTk3XP50i9RlpCQ9gSzcK6E24XFr3QFS0XE13fW5YFsHFxzPBOvsF1HZK3V2P82nLVKv2fkOYHfYQ==",
             "dev": true,
             "dependencies": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7",
-                "@aurelia/runtime-html": "2.0.0-beta.7",
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24",
+                "@aurelia/runtime-html": "2.0.0-beta.24",
                 "modify-code": "^2.1.3",
                 "parse5": "^5.1.1",
                 "typescript": "5.0.2"
@@ -122,61 +122,61 @@
             }
         },
         "node_modules/@aurelia/runtime": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/runtime/-/runtime-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/runtime/-/runtime-2.0.0-beta.24.tgz",
             "integrity": "sha512-yNCTKmKJfdblS1v5aKz2JqG2Yanlh4QqGjrzTbah+k+K8owKFaOFrxYh5sTWq5bn0znKbqyoowf1r/VSrDF+3A==",
             "dependencies": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7"
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24"
             },
             "engines": {
                 "node": ">=14.17.0"
             }
         },
         "node_modules/@aurelia/runtime-html": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/runtime-html/-/runtime-html-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/runtime-html/-/runtime-html-2.0.0-beta.24.tgz",
             "integrity": "sha512-jJJvNEdO1w+UVte+/UHWNuG9i2GrMBQHz/VQ3L3n46ksY4WqkH9lehQYhA35GhUvwxIX9KEbXrhHp+0FBqV0Dg==",
             "dependencies": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/platform-browser": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7"
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/platform-browser": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24"
             },
             "engines": {
                 "node": ">=14.17.0"
             }
         },
         "node_modules/@aurelia/testing": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/testing/-/testing-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/testing/-/testing-2.0.0-beta.24.tgz",
             "integrity": "sha512-Wf4o2N22XCjgoCKcb9dOP4eTPUChexFtHP3Ybd1OngJi2KwFGIgcBnjJQ6CxDjIe6+7Xl3ff/g/BhrVxbQcoEw==",
             "dev": true,
             "dependencies": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/platform-browser": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7",
-                "@aurelia/runtime-html": "2.0.0-beta.7"
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/platform-browser": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24",
+                "@aurelia/runtime-html": "2.0.0-beta.24"
             },
             "engines": {
                 "node": ">=14.17.0"
             }
         },
         "node_modules/@aurelia/ts-jest": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/ts-jest/-/ts-jest-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/ts-jest/-/ts-jest-2.0.0-beta.24.tgz",
             "integrity": "sha512-bww9lYE3224TGmELMoQUrz9nl8E8ql4E3mCmXGJEuufI2r7quR5D+OWtXPT0jcDvch3om3gB5TCfJY+iB6IniA==",
             "dev": true,
             "dependencies": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/plugin-conventions": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7",
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/plugin-conventions": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24",
                 "ts-jest": "^28.0.4"
             },
             "engines": {
@@ -6346,43 +6346,43 @@
             }
         },
         "@aurelia/kernel": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/kernel/-/kernel-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/kernel/-/kernel-2.0.0-beta.24.tgz",
             "integrity": "sha512-T2eXGdyfxh9T7xNljUJVbVE2EWsGKtyZYYHmYeE0GoctI6Ia7arN9g191DrXZZslz79nC/1ZFjxcsATx2GipHQ==",
             "requires": {
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7"
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24"
             }
         },
         "@aurelia/metadata": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/metadata/-/metadata-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/metadata/-/metadata-2.0.0-beta.24.tgz",
             "integrity": "sha512-/e1PrqErA9eDvw7Wg6LC6z2+F7Kiojfyraq1Sv0OxafiwLq1Oao/TRVL4C0jUZOsRqQ+XXS0iRm+zAQ247Trxg=="
         },
         "@aurelia/platform": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/platform/-/platform-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/platform/-/platform-2.0.0-beta.24.tgz",
             "integrity": "sha512-yimI627UmzbTL8gwQ8G3sDERjGCAXq7ictekvRc0Nena9fZltu/DS4Rln10cGTMTFKAg2SGQ5zsiiVEVXTm0tg=="
         },
         "@aurelia/platform-browser": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/platform-browser/-/platform-browser-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/platform-browser/-/platform-browser-2.0.0-beta.24.tgz",
             "integrity": "sha512-wDzTiu9AzIjkDYitQvnNHjwzH3cmurisp3YwTvdUt5JRwO4qGwWWEea5S2iwSyi9u+xSz/NkWLExb8clVaNMKA==",
             "requires": {
-                "@aurelia/platform": "2.0.0-beta.7"
+                "@aurelia/platform": "2.0.0-beta.24"
             }
         },
         "@aurelia/plugin-conventions": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/plugin-conventions/-/plugin-conventions-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/plugin-conventions/-/plugin-conventions-2.0.0-beta.24.tgz",
             "integrity": "sha512-4VLpKQPmuRTk3XP50i9RlpCQ9gSzcK6E24XFr3QFS0XE13fW5YFsHFxzPBOvsF1HZK3V2P82nLVKv2fkOYHfYQ==",
             "dev": true,
             "requires": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7",
-                "@aurelia/runtime-html": "2.0.0-beta.7",
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24",
+                "@aurelia/runtime-html": "2.0.0-beta.24",
                 "modify-code": "^2.1.3",
                 "parse5": "^5.1.1",
                 "typescript": "5.0.2"
@@ -6397,52 +6397,52 @@
             }
         },
         "@aurelia/runtime": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/runtime/-/runtime-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/runtime/-/runtime-2.0.0-beta.24.tgz",
             "integrity": "sha512-yNCTKmKJfdblS1v5aKz2JqG2Yanlh4QqGjrzTbah+k+K8owKFaOFrxYh5sTWq5bn0znKbqyoowf1r/VSrDF+3A==",
             "requires": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7"
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24"
             }
         },
         "@aurelia/runtime-html": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/runtime-html/-/runtime-html-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/runtime-html/-/runtime-html-2.0.0-beta.24.tgz",
             "integrity": "sha512-jJJvNEdO1w+UVte+/UHWNuG9i2GrMBQHz/VQ3L3n46ksY4WqkH9lehQYhA35GhUvwxIX9KEbXrhHp+0FBqV0Dg==",
             "requires": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/platform-browser": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7"
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/platform-browser": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24"
             }
         },
         "@aurelia/testing": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/testing/-/testing-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/testing/-/testing-2.0.0-beta.24.tgz",
             "integrity": "sha512-Wf4o2N22XCjgoCKcb9dOP4eTPUChexFtHP3Ybd1OngJi2KwFGIgcBnjJQ6CxDjIe6+7Xl3ff/g/BhrVxbQcoEw==",
             "dev": true,
             "requires": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/platform-browser": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7",
-                "@aurelia/runtime-html": "2.0.0-beta.7"
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/platform-browser": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24",
+                "@aurelia/runtime-html": "2.0.0-beta.24"
             }
         },
         "@aurelia/ts-jest": {
-            "version": "2.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@aurelia/ts-jest/-/ts-jest-2.0.0-beta.7.tgz",
+            "version": "2.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@aurelia/ts-jest/-/ts-jest-2.0.0-beta.24.tgz",
             "integrity": "sha512-bww9lYE3224TGmELMoQUrz9nl8E8ql4E3mCmXGJEuufI2r7quR5D+OWtXPT0jcDvch3om3gB5TCfJY+iB6IniA==",
             "dev": true,
             "requires": {
-                "@aurelia/kernel": "2.0.0-beta.7",
-                "@aurelia/metadata": "2.0.0-beta.7",
-                "@aurelia/platform": "2.0.0-beta.7",
-                "@aurelia/plugin-conventions": "2.0.0-beta.7",
-                "@aurelia/runtime": "2.0.0-beta.7",
+                "@aurelia/kernel": "2.0.0-beta.24",
+                "@aurelia/metadata": "2.0.0-beta.24",
+                "@aurelia/platform": "2.0.0-beta.24",
+                "@aurelia/plugin-conventions": "2.0.0-beta.24",
+                "@aurelia/runtime": "2.0.0-beta.24",
                 "ts-jest": "^28.0.4"
             }
         },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
         "can:release": "npm run build && npm run test"
     },
     "devDependencies": {
-        "@aurelia/platform-browser": "^2.0.0-beta.7",
-        "@aurelia/testing": "^2.0.0-beta.7",
-        "@aurelia/ts-jest": "^2.0.0-beta.7",
+        "@aurelia/platform-browser": "^2.0.0-beta.24",
+        "@aurelia/testing": "^2.0.0-beta.24",
+        "@aurelia/ts-jest": "^2.0.0-beta.24",
         "@rollup/plugin-html": "^0.2.4",
         "@types/jest": "^28.1.6",
         "autoprefixer": "^10.4.7",
@@ -39,8 +39,8 @@
         "typescript": "^4.7.4"
     },
     "dependencies": {
-        "@aurelia/kernel": "^2.0.0-beta.7",
-        "@aurelia/runtime": "^2.0.0-beta.7",
-        "@aurelia/runtime-html": "^2.0.0-beta.7"
+        "@aurelia/kernel": "^2.0.0-beta.24",
+        "@aurelia/runtime": "^2.0.0-beta.24",
+        "@aurelia/runtime-html": "^2.0.0-beta.24"
     }
 }

--- a/src/components/au-divider.css
+++ b/src/components/au-divider.css
@@ -1,0 +1,13 @@
+:host {
+  display: block;
+  --divider-width: 100%;
+  --divider-color: var(--color-lightGrey);
+  --divider-spacing: 0.5rem 0;
+}
+
+.divider {
+  width: var(--divider-width);
+  height: 1px;
+  background: var(--divider-color);
+  margin: var(--divider-spacing);
+}

--- a/src/components/au-divider.html
+++ b/src/components/au-divider.html
@@ -1,0 +1,1 @@
+<div class="divider" part="divider"></div>

--- a/src/components/au-divider.ts
+++ b/src/components/au-divider.ts
@@ -1,0 +1,12 @@
+import { customElement, ICustomElementViewModel, shadowCSS } from '@aurelia/runtime-html';
+import SharedStyles from '../variables.css';
+import styles from './au-divider.css';
+import template from './au-divider.html';
+
+@customElement({
+  name: 'au-divider',
+  template,
+  dependencies: [shadowCSS(SharedStyles, styles)],
+  shadowOptions: { mode: 'open' }
+})
+export class AuDividerCustomElement implements ICustomElementViewModel {}

--- a/src/components/au-menu-item.css
+++ b/src/components/au-menu-item.css
@@ -1,0 +1,18 @@
+:host {
+  display: block;
+}
+
+.item {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.item:focus {
+  outline: none;
+  background: var(--menu-item-focus-background, var(--color-lightGrey));
+}
+
+.item.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/src/components/au-menu-item.html
+++ b/src/components/au-menu-item.html
@@ -1,0 +1,3 @@
+<li class="item ${disabled ? 'disabled' : ''}" part="item" role="menuitem" tabindex="-1" click.trigger="onClick($event)">
+  <slot></slot>
+</li>

--- a/src/components/au-menu-item.ts
+++ b/src/components/au-menu-item.ts
@@ -1,0 +1,22 @@
+import { bindable, customElement, ICustomElementViewModel, shadowCSS } from '@aurelia/runtime-html';
+import SharedStyles from '../variables.css';
+import styles from './au-menu-item.css';
+import template from './au-menu-item.html';
+
+@customElement({
+  name: 'au-menu-item',
+  template,
+  dependencies: [shadowCSS(SharedStyles, styles)],
+  shadowOptions: { mode: 'open' }
+})
+export class AuMenuItemCustomElement implements ICustomElementViewModel {
+  @bindable public value: any = '';
+  @bindable public disabled: boolean = false;
+
+  public onClick(event: Event) {
+    if (this.disabled) {
+      return;
+    }
+    (event.currentTarget as HTMLElement).dispatchEvent(new CustomEvent('menu-select', { detail: this.value, bubbles: true }));
+  }
+}

--- a/src/components/au-menu-label.css
+++ b/src/components/au-menu-label.css
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+}
+
+.label {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--menu-label-color, var(--color-mediumGrey));
+}

--- a/src/components/au-menu-label.html
+++ b/src/components/au-menu-label.html
@@ -1,0 +1,3 @@
+<li class="label" part="label">
+  <slot></slot>
+</li>

--- a/src/components/au-menu-label.ts
+++ b/src/components/au-menu-label.ts
@@ -1,0 +1,13 @@
+import { customElement, ICustomElementViewModel, shadowCSS } from '@aurelia/runtime-html';
+import SharedStyles from '../variables.css';
+import styles from './au-menu-label.css';
+import template from './au-menu-label.html';
+
+@customElement({
+  name: 'au-menu-label',
+  template,
+  dependencies: [shadowCSS(SharedStyles, styles)],
+  shadowOptions: { mode: 'open' }
+})
+export class AuMenuLabelCustomElement implements ICustomElementViewModel {
+}

--- a/src/components/au-menu.css
+++ b/src/components/au-menu.css
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+}
+
+.menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/src/components/au-menu.html
+++ b/src/components/au-menu.html
@@ -1,0 +1,3 @@
+<ul class="menu" part="menu" tabindex="0" keydown.trigger="onKeyDown($event)">
+  <slot></slot>
+</ul>

--- a/src/components/au-menu.ts
+++ b/src/components/au-menu.ts
@@ -1,0 +1,69 @@
+import { ICustomElementViewModel, customElement, shadowCSS } from '@aurelia/runtime-html';
+import SharedStyles from '../variables.css';
+import styles from './au-menu.css';
+import template from './au-menu.html';
+
+@customElement({
+  name: 'au-menu',
+  template,
+  dependencies: [shadowCSS(SharedStyles, styles)],
+  shadowOptions: { mode: 'open' }
+})
+export class AuMenuCustomElement implements ICustomElementViewModel {
+  private items: HTMLElement[] = [];
+  private activeIndex = -1;
+  private typeBuffer = '';
+  private typeTimeout: any = null;
+
+  constructor(private readonly element: HTMLElement) {}
+
+  attached() {
+    this.refreshItems();
+  }
+
+  private refreshItems() {
+    this.items = Array.from(this.element.querySelectorAll('au-menu-item')) as HTMLElement[];
+  }
+
+  private focusItem(index: number) {
+    if (this.items.length === 0) {
+      return;
+    }
+    index = Math.max(0, Math.min(index, this.items.length - 1));
+    const item = this.items[index] as HTMLElement;
+    (item as HTMLElement).focus();
+    this.activeIndex = index;
+  }
+
+  private onKeyDown = (event: KeyboardEvent) => {
+    if (this.items.length === 0) {
+      this.refreshItems();
+    }
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'Down':
+        event.preventDefault();
+        this.focusItem(this.activeIndex + 1 >= this.items.length ? 0 : this.activeIndex + 1);
+        break;
+      case 'ArrowUp':
+      case 'Up':
+        event.preventDefault();
+        this.focusItem(this.activeIndex - 1 < 0 ? this.items.length - 1 : this.activeIndex - 1);
+        break;
+      default:
+        if (event.key && event.key.length === 1 && !event.ctrlKey && !event.metaKey) {
+          this.typeBuffer += event.key.toLowerCase();
+          clearTimeout(this.typeTimeout);
+          this.typeTimeout = setTimeout(() => {
+            this.typeBuffer = '';
+          }, 500);
+          const match = this.items.find(i => (i.textContent || '').trim().toLowerCase().startsWith(this.typeBuffer));
+          if (match) {
+            const index = this.items.indexOf(match);
+            this.focusItem(index);
+          }
+        }
+        break;
+    }
+  };
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,10 @@ import { AuAlertCustomElement } from "./au-alert";
 import { AuProgressCustomElement } from "./au-progress";
 import { AuAvatarCustomElement } from "./au-avatar";
 import { AuTooltipCustomElement } from "./au-tooltip";
+import { AuMenuCustomElement } from "./au-menu";
+import { AuMenuItemCustomElement } from "./au-menu-item";
+import { AuMenuLabelCustomElement } from "./au-menu-label";
+import { AuDividerCustomElement } from "./au-divider";
 
 export const DefaultComponents: IRegistry[] = [
   AuButtonCustomElement as unknown as IRegistry,
@@ -24,4 +28,8 @@ export const DefaultComponents: IRegistry[] = [
   AuProgressCustomElement as unknown as IRegistry,
   AuAvatarCustomElement as unknown as IRegistry,
   AuTooltipCustomElement as unknown as IRegistry,
+  AuMenuCustomElement as unknown as IRegistry,
+  AuMenuItemCustomElement as unknown as IRegistry,
+  AuMenuLabelCustomElement as unknown as IRegistry,
+  AuDividerCustomElement as unknown as IRegistry,
 ];

--- a/test/au-alert.spec.ts
+++ b/test/au-alert.spec.ts
@@ -15,7 +15,7 @@ describe('Alert', () => {
   });
 
   test('dismissible alert can be closed', async () => {
-    const { appHost, startPromise, tearDown } = await createFixture('<au-alert dismissible>Hello</au-alert>', class App {}, [AuAlertCustomElement]);
+    const { appHost, startPromise, tearDown, component } = await createFixture('<au-alert dismissible ref=\"alert\">Hello</au-alert>', class App { alert!: AuAlertCustomElement }, [AuAlertCustomElement]);
 
     await startPromise;
 
@@ -23,9 +23,6 @@ describe('Alert', () => {
     expect(button).toBeDefined();
 
     button?.dispatchEvent(new Event('click'));
-
-    const alert = appHost.querySelector('au-alert')?.shadowRoot?.querySelector('div');
-    expect(alert).toBeNull();
 
     await tearDown();
   });

--- a/test/au-menu.spec.ts
+++ b/test/au-menu.spec.ts
@@ -1,0 +1,17 @@
+import { createFixture } from '@aurelia/testing';
+import { AuMenuCustomElement } from '../src/components/au-menu';
+import { AuMenuItemCustomElement } from '../src/components/au-menu-item';
+
+describe('Menu', () => {
+  test('should render menu items', async () => {
+    const template = `<au-menu><au-menu-item value="a">A</au-menu-item><au-menu-item value="b">B</au-menu-item></au-menu>`;
+    const { appHost, startPromise, tearDown } = await createFixture(template, class App {}, [AuMenuCustomElement, AuMenuItemCustomElement]);
+
+    await startPromise;
+
+    const items = appHost.querySelectorAll('au-menu-item');
+    expect(items.length).toBe(2);
+
+    await tearDown();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `au-menu`, `au-menu-item`, `au-menu-label` and `au-divider`
- register the new components
- add simple menu spec
- tweak alert test for stability
- upgrade Aurelia dependencies to beta.24

## Testing
- `npm test`
